### PR TITLE
os_rescue: document side effects, auth-method selection, no-op Read/Delete

### DIFF
--- a/docs/resources/os_rescue.md
+++ b/docs/resources/os_rescue.md
@@ -3,12 +3,12 @@
 page_title: "hetznerrobot_os_rescue Resource - hetznerrobot"
 subcategory: ""
 description: |-
-  
+  Activates the Hetzner Robot rescue system on a server and triggers a hardware reset to boot into it. Create issues a hw reset (equivalent to pressing the reset button), waits for the rescue system's SSH port to come up, and renames the server. Update only handles server_name changes; all other fields are effectively immutable. Read and Delete are no-ops, so destroying the resource does not deactivate rescue mode or reboot the server back to its installed OS — once rescue activates and you reboot, the server comes up normally on its next boot regardless of Terraform state.
 ---
 
 # hetznerrobot_os_rescue (Resource)
 
-
+Activates the Hetzner Robot rescue system on a server and triggers a hardware reset to boot into it. Create issues a `hw` reset (equivalent to pressing the reset button), waits for the rescue system's SSH port to come up, and renames the server. Update only handles `server_name` changes; all other fields are effectively immutable. Read and Delete are no-ops, so destroying the resource does not deactivate rescue mode or reboot the server back to its installed OS — once rescue activates and you reboot, the server comes up normally on its next boot regardless of Terraform state.
 
 ## Example Usage
 
@@ -24,16 +24,16 @@ resource "hetznerrobot_os_rescue" "test" {
 
 ### Required
 
-- `server_id` (String) Server ID.
-- `server_name` (String) The server will be renamed to this name.
+- `server_id` (String) Server ID (Hetzner server number).
+- `server_name` (String) Name to assign to the server after the rescue system is reachable. The only field whose change is honored by Update.
 
 ### Optional
 
-- `rescue_os` (String) Operating system for rescue mode (e.g. linux, freebsd).
-- `ssh_keys` (List of String) List of SSH keys to be added during the rescue mode.
+- `rescue_os` (String) Operating system image to boot in rescue mode (e.g. `linux`, `linuxold`, `freebsd`, `vkvm`). Changing this in-place is not supported by Update.
+- `ssh_keys` (List of String) Public SSH keys to install in the rescue system's authorized_keys. If non-empty, the rescue system disables password authentication and `ssh_password` will be empty. If left empty, Hetzner generates a one-shot root password (returned in `ssh_password`).
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `ip` (String) Server public IP.
-- `ssh_password` (String, Sensitive) Current Rescue System root password.
+- `ip` (String) Public IPv4 of the rescue system, returned by the activation call.
+- `ssh_password` (String, Sensitive) One-shot root password for the rescue system. Set only when `ssh_keys` is empty; otherwise this is empty and you authenticate with one of the listed keys.

--- a/internal/server/os_rescue.go
+++ b/internal/server/os_rescue.go
@@ -21,6 +21,12 @@ const (
 // ResourceOSRescue defines the os_rescue terraform resource.
 func ResourceOSRescue() *schema.Resource {
 	return &schema.Resource{
+		Description: "Activates the Hetzner Robot rescue system on a server and triggers a hardware reset to boot into it. " +
+			"Create issues a `hw` reset (equivalent to pressing the reset button), waits for the rescue system's SSH " +
+			"port to come up, and renames the server. Update only handles `server_name` changes; all other fields are " +
+			"effectively immutable. Read and Delete are no-ops, so destroying the resource does not deactivate rescue " +
+			"mode or reboot the server back to its installed OS — once rescue activates and you reboot, the server " +
+			"comes up normally on its next boot regardless of Terraform state.",
 		CreateContext: resourceOSRescueCreate,
 		ReadContext:   schema.NoopContext,
 		UpdateContext: resourceOSRescueUpdate,
@@ -29,35 +35,38 @@ func ResourceOSRescue() *schema.Resource {
 			"server_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The server will be renamed to this name.",
+				Description: "Name to assign to the server after the rescue system is reachable. The only field whose change is honored by Update.",
 			},
 			"server_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Server ID.",
+				Description: "Server ID (Hetzner server number).",
 			},
 			"rescue_os": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "linux",
-				Description: "Operating system for rescue mode (e.g. linux, freebsd).",
+				Description: "Operating system image to boot in rescue mode (e.g. `linux`, `linuxold`, `freebsd`, `vkvm`). Changing this in-place is not supported by Update.",
 			},
 			"ssh_keys": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "List of SSH keys to be added during the rescue mode.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: "Public SSH keys to install in the rescue system's authorized_keys. " +
+					"If non-empty, the rescue system disables password authentication and `ssh_password` will be empty. " +
+					"If left empty, Hetzner generates a one-shot root password (returned in `ssh_password`).",
+				Elem: &schema.Schema{Type: schema.TypeString},
 			},
 			"ip": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Server public IP.",
+				Description: "Public IPv4 of the rescue system, returned by the activation call.",
 			},
 			"ssh_password": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Sensitive:   true,
-				Description: "Current Rescue System root password.",
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+				Description: "One-shot root password for the rescue system. " +
+					"Set only when `ssh_keys` is empty; otherwise this is empty and you authenticate with one of the listed keys.",
 			},
 		},
 	}


### PR DESCRIPTION
The os_rescue resource silently performs three side effects on Create that none of its docs mentioned: a hardware reset, a 3-minute wait for SSH on the rescue system, and a server rename. Update is a partial — it only honors server_name changes and ignores everything else. Read and Delete are no-ops, so destroying the resource leaves the rescue arming intact and does not reboot the server back to the installed OS.

Add a top-level resource Description covering all of the above, and expand each schema field's description: ssh_keys now explains that non-empty disables password authentication, ssh_password notes it is populated only when ssh_keys is empty, rescue_os lists the supported images, and the immutability of every field other than server_name is called out where relevant.

Doc-only change; no schema or behavior change.