### PR TITLE
feat(firewall): expose ip_version per rule + filter_ipv6 top-level

### DIFF
--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -37,10 +37,9 @@ resource "hetznerrobot_firewall" "firewall" {
   }
 }
 
-# Example with IPv6 also filtered: set filter_ipv6 = true and add explicit
-# rules with ip_version = "ipv6" alongside the ipv4 rules. Per the Hetzner
-# API, `ip_version` is required whenever `protocol` is set on a rule, and
-# IPv4 and IPv6 are evaluated against separate per-rule ip_version values.
+# Example with IPv6 also filtered:
+# * set filter_ipv6 = true
+# * add explicit rules with ip_version = "ipv6" alongside the ipv4 rules
 resource "hetznerrobot_firewall" "firewall_ipv6" {
   server_id     = 7654321
   active        = true

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -17,7 +17,13 @@ resource "hetznerrobot_firewall" "firewall" {
   server_id     = 1234567
   active        = true
   whitelist_hos = true
+  # Set true to also evaluate IPv6 packets against the rule list. When false
+  # (Hetzner default), IPv6 traffic bypasses all rules.
+  filter_ipv6 = true
 
+  # Each rule defaults to ip_version = "ipv4" if not specified, matching the
+  # behavior of pre-1.5.0 versions of this provider. Per the Hetzner API,
+  # `ip_version` is required whenever `protocol` is set on a rule.
   rule {
     name     = "icmp"
     protocol = "icmp"
@@ -29,6 +35,15 @@ resource "hetznerrobot_firewall" "firewall" {
     protocol = "tcp"
     dst_port = "22"
     action   = "accept"
+  }
+
+  # IPv6 variant of the SSH rule.
+  rule {
+    ip_version = "ipv6"
+    name       = "ssh-v6"
+    protocol   = "tcp"
+    dst_port   = "22"
+    action     = "accept"
   }
 
   rule {
@@ -48,6 +63,10 @@ resource "hetznerrobot_firewall" "firewall" {
 - `server_id` (String) ID of the server to which the firewall will be applied.
 - `whitelist_hos` (Boolean) Whether to whitelist Hetzner services.
 
+### Optional
+
+- `filter_ipv6` (Boolean) Whether to also filter IPv6 packets. When false (Hetzner default), only IPv4 rules apply and IPv6 traffic is unrestricted. When true, IPv6 traffic is evaluated against the rule list using the per-rule ip_version field.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
@@ -63,6 +82,7 @@ Optional:
 
 - `dst_ip` (String) Destination IP address.
 - `dst_port` (String) Destination port.
+- `ip_version` (String) IP version this rule matches against (ipv4 or ipv6). Defaults to ipv4 to preserve behavior of pre-1.5.0 versions of this provider, which hardcoded ipv4. Note: per the Hetzner Robot API, rules with a `protocol` value require `ip_version` to be set.
 - `name` (String) Name of the firewall rule.
 - `protocol` (String) Protocol (e.g., tcp, udp).
 - `src_ip` (String) Source IP address.

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -17,13 +17,7 @@ resource "hetznerrobot_firewall" "firewall" {
   server_id     = 1234567
   active        = true
   whitelist_hos = true
-  # Set true to also evaluate IPv6 packets against the rule list. When false
-  # (Hetzner default), IPv6 traffic bypasses all rules.
-  filter_ipv6 = true
 
-  # Each rule defaults to ip_version = "ipv4" if not specified, matching the
-  # behavior of pre-1.5.0 versions of this provider. Per the Hetzner API,
-  # `ip_version` is required whenever `protocol` is set on a rule.
   rule {
     name     = "icmp"
     protocol = "icmp"
@@ -37,7 +31,32 @@ resource "hetznerrobot_firewall" "firewall" {
     action   = "accept"
   }
 
-  # IPv6 variant of the SSH rule.
+  rule {
+    name   = "Deny others"
+    action = "discard"
+  }
+}
+
+# Example with IPv6 also filtered: set filter_ipv6 = true and add explicit
+# rules with ip_version = "ipv6" alongside the ipv4 rules. Per the Hetzner
+# API, `ip_version` is required whenever `protocol` is set on a rule, and
+# IPv4 and IPv6 are evaluated against separate per-rule ip_version values.
+resource "hetznerrobot_firewall" "firewall_ipv6" {
+  server_id     = 7654321
+  active        = true
+  whitelist_hos = true
+  # Set true to also evaluate IPv6 packets against the rule list.
+  # When false (default), IPv6 traffic bypasses all rules.
+  filter_ipv6 = true
+
+  rule {
+    ip_version = "ipv4"
+    name       = "ssh-v4"
+    protocol   = "tcp"
+    dst_port   = "22"
+    action     = "accept"
+  }
+
   rule {
     ip_version = "ipv6"
     name       = "ssh-v6"

--- a/examples/resources/hetznerrobot_firewall/resource.tf
+++ b/examples/resources/hetznerrobot_firewall/resource.tf
@@ -22,10 +22,9 @@ resource "hetznerrobot_firewall" "firewall" {
   }
 }
 
-# Example with IPv6 also filtered: set filter_ipv6 = true and add explicit
-# rules with ip_version = "ipv6" alongside the ipv4 rules. Per the Hetzner
-# API, `ip_version` is required whenever `protocol` is set on a rule, and
-# IPv4 and IPv6 are evaluated against separate per-rule ip_version values.
+# Example with IPv6 also filtered:
+# * set filter_ipv6 = true
+# * add explicit rules with ip_version = "ipv6" alongside the ipv4 rules
 resource "hetznerrobot_firewall" "firewall_ipv6" {
   server_id     = 7654321
   active        = true

--- a/examples/resources/hetznerrobot_firewall/resource.tf
+++ b/examples/resources/hetznerrobot_firewall/resource.tf
@@ -2,13 +2,7 @@ resource "hetznerrobot_firewall" "firewall" {
   server_id     = 1234567
   active        = true
   whitelist_hos = true
-  # Set true to also evaluate IPv6 packets against the rule list. When false
-  # (Hetzner default), IPv6 traffic bypasses all rules.
-  filter_ipv6 = true
 
-  # Each rule defaults to ip_version = "ipv4" if not specified, matching the
-  # behavior of pre-1.5.0 versions of this provider. Per the Hetzner API,
-  # `ip_version` is required whenever `protocol` is set on a rule.
   rule {
     name     = "icmp"
     protocol = "icmp"
@@ -22,7 +16,32 @@ resource "hetznerrobot_firewall" "firewall" {
     action   = "accept"
   }
 
-  # IPv6 variant of the SSH rule.
+  rule {
+    name   = "Deny others"
+    action = "discard"
+  }
+}
+
+# Example with IPv6 also filtered: set filter_ipv6 = true and add explicit
+# rules with ip_version = "ipv6" alongside the ipv4 rules. Per the Hetzner
+# API, `ip_version` is required whenever `protocol` is set on a rule, and
+# IPv4 and IPv6 are evaluated against separate per-rule ip_version values.
+resource "hetznerrobot_firewall" "firewall_ipv6" {
+  server_id     = 7654321
+  active        = true
+  whitelist_hos = true
+  # Set true to also evaluate IPv6 packets against the rule list.
+  # When false (default), IPv6 traffic bypasses all rules.
+  filter_ipv6 = true
+
+  rule {
+    ip_version = "ipv4"
+    name       = "ssh-v4"
+    protocol   = "tcp"
+    dst_port   = "22"
+    action     = "accept"
+  }
+
   rule {
     ip_version = "ipv6"
     name       = "ssh-v6"

--- a/examples/resources/hetznerrobot_firewall/resource.tf
+++ b/examples/resources/hetznerrobot_firewall/resource.tf
@@ -2,7 +2,13 @@ resource "hetznerrobot_firewall" "firewall" {
   server_id     = 1234567
   active        = true
   whitelist_hos = true
+  # Set true to also evaluate IPv6 packets against the rule list. When false
+  # (Hetzner default), IPv6 traffic bypasses all rules.
+  filter_ipv6 = true
 
+  # Each rule defaults to ip_version = "ipv4" if not specified, matching the
+  # behavior of pre-1.5.0 versions of this provider. Per the Hetzner API,
+  # `ip_version` is required whenever `protocol` is set on a rule.
   rule {
     name     = "icmp"
     protocol = "icmp"
@@ -14,6 +20,15 @@ resource "hetznerrobot_firewall" "firewall" {
     protocol = "tcp"
     dst_port = "22"
     action   = "accept"
+  }
+
+  # IPv6 variant of the SSH rule.
+  rule {
+    ip_version = "ipv6"
+    name       = "ssh-v6"
+    protocol   = "tcp"
+    dst_port   = "22"
+    action     = "accept"
   }
 
   rule {

--- a/internal/client/firewall.go
+++ b/internal/client/firewall.go
@@ -16,6 +16,7 @@ import (
 type Firewall struct {
 	IP                       string        `json:"ip"`
 	WhitelistHetznerServices bool          `json:"whitelist_hos"`
+	FilterIPv6               bool          `json:"filter_ipv6"`
 	Status                   string        `json:"status"`
 	Rules                    FirewallRules `json:"rules"`
 }
@@ -27,14 +28,15 @@ type FirewallRules struct {
 
 // FirewallRule defines a firewall rule for FirewallRules.
 type FirewallRule struct {
-	Name     string `json:"name,omitempty"`
-	SrcIP    string `json:"src_ip,omitempty"`
-	SrcPort  string `json:"src_port,omitempty"`
-	DstIP    string `json:"dst_ip,omitempty"`
-	DstPort  string `json:"dst_port,omitempty"`
-	Protocol string `json:"protocol,omitempty"`
-	TCPFlags string `json:"tcp_flags,omitempty"`
-	Action   string `json:"action"`
+	IPVersion string `json:"ip_version,omitempty"`
+	Name      string `json:"name,omitempty"`
+	SrcIP     string `json:"src_ip,omitempty"`
+	SrcPort   string `json:"src_port,omitempty"`
+	DstIP     string `json:"dst_ip,omitempty"`
+	DstPort   string `json:"dst_port,omitempty"`
+	Protocol  string `json:"protocol,omitempty"`
+	TCPFlags  string `json:"tcp_flags,omitempty"`
+	Action    string `json:"action"`
 }
 
 // FirewallResponse defines the response from /firewall.
@@ -81,10 +83,17 @@ func (c *HetznerRobotClient) SetFirewall(
 
 	data := url.Values{}
 	data.Set("whitelist_hos", strconv.FormatBool(firewall.WhitelistHetznerServices))
+	data.Set("filter_ipv6", strconv.FormatBool(firewall.FilterIPv6))
 	data.Set("status", firewall.Status)
 
 	for index, rule := range firewall.Rules.Input {
-		data.Set(fmt.Sprintf("rules[input][%d][ip_version]", index), "ipv4")
+		// Default to ipv4 when the caller doesn't specify, preserving the
+		// behavior of pre-ip_version-aware versions of this provider.
+		ipVersion := rule.IPVersion
+		if ipVersion == "" {
+			ipVersion = "ipv4"
+		}
+		data.Set(fmt.Sprintf("rules[input][%d][ip_version]", index), ipVersion)
 
 		fields := map[string]string{
 			"name":      rule.Name,

--- a/internal/client/firewall.go
+++ b/internal/client/firewall.go
@@ -87,8 +87,7 @@ func (c *HetznerRobotClient) SetFirewall(
 	data.Set("status", firewall.Status)
 
 	for index, rule := range firewall.Rules.Input {
-		// Default to ipv4 when the caller doesn't specify, preserving the
-		// behavior of pre-ip_version-aware versions of this provider.
+		// Default to ipv4 when the caller doesn't specify.
 		ipVersion := rule.IPVersion
 		if ipVersion == "" {
 			ipVersion = "ipv4"

--- a/internal/client/firewall.go
+++ b/internal/client/firewall.go
@@ -92,6 +92,7 @@ func (c *HetznerRobotClient) SetFirewall(
 		if ipVersion == "" {
 			ipVersion = "ipv4"
 		}
+
 		data.Set(fmt.Sprintf("rules[input][%d][ip_version]", index), ipVersion)
 
 		fields := map[string]string{

--- a/internal/client/firewall_test.go
+++ b/internal/client/firewall_test.go
@@ -11,23 +11,34 @@ import (
 var testFirewall = client.Firewall{
 	IP:                       "1.2.3.4",
 	WhitelistHetznerServices: true,
+	FilterIPv6:               true,
 	Status:                   "active",
 	Rules: client.FirewallRules{
 		//exhaustruct:ignore
 		Input: []client.FirewallRule{
 			{
-				Name:     "allow-ssh",
-				SrcIP:    "0.0.0.0/0",
-				DstPort:  "22",
-				Protocol: "tcp",
-				Action:   "accept",
+				IPVersion: "ipv4",
+				Name:      "allow-ssh",
+				SrcIP:     "0.0.0.0/0",
+				DstPort:   "22",
+				Protocol:  "tcp",
+				Action:    "accept",
 			},
 			{
-				Name:     "allow-http",
-				SrcIP:    "0.0.0.0/0",
-				DstPort:  "80",
-				Protocol: "tcp",
-				Action:   "accept",
+				IPVersion: "ipv4",
+				Name:      "allow-http",
+				SrcIP:     "0.0.0.0/0",
+				DstPort:   "80",
+				Protocol:  "tcp",
+				Action:    "accept",
+			},
+			{
+				IPVersion: "ipv6",
+				Name:      "allow-ssh-v6",
+				SrcIP:     "::/0",
+				DstPort:   "22",
+				Protocol:  "tcp",
+				Action:    "accept",
 			},
 		},
 	},
@@ -62,6 +73,14 @@ func TestGetFirewall(t *testing.T) {
 		)
 	}
 
+	if testFirewall.FilterIPv6 != firewall.FilterIPv6 {
+		t.Errorf(
+			"FilterIPv6: want %t, got %t",
+			testFirewall.FilterIPv6,
+			firewall.FilterIPv6,
+		)
+	}
+
 	if testFirewall.Status != firewall.Status {
 		t.Errorf("Status: want %v, got %v", testFirewall.Status, firewall.Status)
 	}
@@ -76,6 +95,10 @@ func TestGetFirewall(t *testing.T) {
 
 	for i, wantRule := range testFirewall.Rules.Input {
 		gotRule := firewall.Rules.Input[i]
+		if wantRule.IPVersion != gotRule.IPVersion {
+			t.Errorf("Rule[%d] IPVersion: want %v, got %v", i, wantRule.IPVersion, gotRule.IPVersion)
+		}
+
 		if wantRule.Name != gotRule.Name {
 			t.Errorf("Rule[%d] Name: want %v, got %v", i, wantRule.Name, gotRule.Name)
 		}

--- a/internal/client/firewall_test.go
+++ b/internal/client/firewall_test.go
@@ -33,14 +33,6 @@ var testFirewall = client.Firewall{
 	},
 }
 
-// testFirewallIPv6 mirrors testFirewall with filter_ipv6 enabled and adds an
-// IPv6 SSH rule alongside the IPv4 ones, to exercise SetFirewall's handling of
-// the per-rule ip_version field and the top-level filter_ipv6 field on the
-// wire. GET round-trip is covered by TestGetFirewall against the default v4
-// fixture; the mock server returns a single fixed example so we can't easily
-// vary the GET response per test, but POST request validation against the
-// OpenAPI schema catches malformed payloads regardless.
-//
 //nolint:gochecknoglobals
 var testFirewallIPv6 = client.Firewall{
 	IP:                       "1.2.3.4",
@@ -171,9 +163,6 @@ func TestSetFirewall(t *testing.T) {
 	}
 }
 
-// TestSetFirewallIPv6 exercises SetFirewall with the IPv6 fixture. The mock
-// server validates the POST body against the OpenAPI schema, so a malformed
-// filter_ipv6 / ip_version payload would fail validation and surface here.
 func TestSetFirewallIPv6(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/firewall_test.go
+++ b/internal/client/firewall_test.go
@@ -11,6 +11,7 @@ import (
 var testFirewall = client.Firewall{
 	IP:                       "1.2.3.4",
 	WhitelistHetznerServices: true,
+	FilterIPv6:               false,
 	Status:                   "active",
 	Rules: client.FirewallRules{
 		//exhaustruct:ignore

--- a/internal/client/firewall_test.go
+++ b/internal/client/firewall_test.go
@@ -11,6 +11,40 @@ import (
 var testFirewall = client.Firewall{
 	IP:                       "1.2.3.4",
 	WhitelistHetznerServices: true,
+	Status:                   "active",
+	Rules: client.FirewallRules{
+		//exhaustruct:ignore
+		Input: []client.FirewallRule{
+			{
+				Name:     "allow-ssh",
+				SrcIP:    "0.0.0.0/0",
+				DstPort:  "22",
+				Protocol: "tcp",
+				Action:   "accept",
+			},
+			{
+				Name:     "allow-http",
+				SrcIP:    "0.0.0.0/0",
+				DstPort:  "80",
+				Protocol: "tcp",
+				Action:   "accept",
+			},
+		},
+	},
+}
+
+// testFirewallIPv6 mirrors testFirewall with filter_ipv6 enabled and adds an
+// IPv6 SSH rule alongside the IPv4 ones, to exercise SetFirewall's handling of
+// the per-rule ip_version field and the top-level filter_ipv6 field on the
+// wire. GET round-trip is covered by TestGetFirewall against the default v4
+// fixture; the mock server returns a single fixed example so we can't easily
+// vary the GET response per test, but POST request validation against the
+// OpenAPI schema catches malformed payloads regardless.
+//
+//nolint:gochecknoglobals
+var testFirewallIPv6 = client.Firewall{
+	IP:                       "1.2.3.4",
+	WhitelistHetznerServices: true,
 	FilterIPv6:               true,
 	Status:                   "active",
 	Rules: client.FirewallRules{
@@ -73,14 +107,6 @@ func TestGetFirewall(t *testing.T) {
 		)
 	}
 
-	if testFirewall.FilterIPv6 != firewall.FilterIPv6 {
-		t.Errorf(
-			"FilterIPv6: want %t, got %t",
-			testFirewall.FilterIPv6,
-			firewall.FilterIPv6,
-		)
-	}
-
 	if testFirewall.Status != firewall.Status {
 		t.Errorf("Status: want %v, got %v", testFirewall.Status, firewall.Status)
 	}
@@ -95,10 +121,6 @@ func TestGetFirewall(t *testing.T) {
 
 	for i, wantRule := range testFirewall.Rules.Input {
 		gotRule := firewall.Rules.Input[i]
-		if wantRule.IPVersion != gotRule.IPVersion {
-			t.Errorf("Rule[%d] IPVersion: want %v, got %v", i, wantRule.IPVersion, gotRule.IPVersion)
-		}
-
 		if wantRule.Name != gotRule.Name {
 			t.Errorf("Rule[%d] Name: want %v, got %v", i, wantRule.Name, gotRule.Name)
 		}
@@ -144,6 +166,27 @@ func TestSetFirewall(t *testing.T) {
 	})
 
 	err := client.SetFirewall(context.Background(), testFirewall)
+	if err != nil {
+		t.Errorf("SetFirewall() error: %v", err)
+	}
+}
+
+// TestSetFirewallIPv6 exercises SetFirewall with the IPv6 fixture. The mock
+// server validates the POST body against the OpenAPI schema, so a malformed
+// filter_ipv6 / ip_version payload would fail validation and surface here.
+func TestSetFirewallIPv6(t *testing.T) {
+	t.Parallel()
+
+	server := mockServer()
+	defer server.Close()
+
+	client := client.New(&client.ProviderConfig{
+		Username: testUsername,
+		Password: testPassword,
+		BaseURL:  server.URL,
+	})
+
+	err := client.SetFirewall(context.Background(), testFirewallIPv6)
 	if err != nil {
 		t.Errorf("SetFirewall() error: %v", err)
 	}

--- a/internal/client/mock.yaml
+++ b/internal/client/mock.yaml
@@ -1451,17 +1451,26 @@ paths:
                 firewall:
                   ip: "1.2.3.4"
                   whitelist_hos: true
+                  filter_ipv6: true
                   status: "active"
                   rules:
                     input:
-                      - name: allow-ssh
+                      - ip_version: ipv4
+                        name: allow-ssh
                         src_ip: 0.0.0.0/0
                         dst_port: "22"
                         protocol: tcp
                         action: accept
-                      - name: allow-http
+                      - ip_version: ipv4
+                        name: allow-http
                         src_ip: 0.0.0.0/0
                         dst_port: "80"
+                        protocol: tcp
+                        action: accept
+                      - ip_version: ipv6
+                        name: allow-ssh-v6
+                        src_ip: "::/0"
+                        dst_port: "22"
                         protocol: tcp
                         action: accept
         '404':
@@ -1527,17 +1536,26 @@ paths:
                 firewall:
                   ip: "1.2.3.4"
                   whitelist_hos: true
+                  filter_ipv6: true
                   status: "active"
                   rules:
                     input:
-                      - name: allow-ssh
+                      - ip_version: ipv4
+                        name: allow-ssh
                         src_ip: 0.0.0.0/0
                         dst_port: "22"
                         protocol: tcp
                         action: accept
-                      - name: allow-http
+                      - ip_version: ipv4
+                        name: allow-http
                         src_ip: 0.0.0.0/0
                         dst_port: "80"
+                        protocol: tcp
+                        action: accept
+                      - ip_version: ipv6
+                        name: allow-ssh-v6
+                        src_ip: "::/0"
+                        dst_port: "22"
                         protocol: tcp
                         action: accept
         '400':

--- a/internal/client/mock.yaml
+++ b/internal/client/mock.yaml
@@ -1451,26 +1451,17 @@ paths:
                 firewall:
                   ip: "1.2.3.4"
                   whitelist_hos: true
-                  filter_ipv6: true
                   status: "active"
                   rules:
                     input:
-                      - ip_version: ipv4
-                        name: allow-ssh
+                      - name: allow-ssh
                         src_ip: 0.0.0.0/0
                         dst_port: "22"
                         protocol: tcp
                         action: accept
-                      - ip_version: ipv4
-                        name: allow-http
+                      - name: allow-http
                         src_ip: 0.0.0.0/0
                         dst_port: "80"
-                        protocol: tcp
-                        action: accept
-                      - ip_version: ipv6
-                        name: allow-ssh-v6
-                        src_ip: "::/0"
-                        dst_port: "22"
                         protocol: tcp
                         action: accept
         '404':
@@ -1536,26 +1527,17 @@ paths:
                 firewall:
                   ip: "1.2.3.4"
                   whitelist_hos: true
-                  filter_ipv6: true
                   status: "active"
                   rules:
                     input:
-                      - ip_version: ipv4
-                        name: allow-ssh
+                      - name: allow-ssh
                         src_ip: 0.0.0.0/0
                         dst_port: "22"
                         protocol: tcp
                         action: accept
-                      - ip_version: ipv4
-                        name: allow-http
+                      - name: allow-http
                         src_ip: 0.0.0.0/0
                         dst_port: "80"
-                        protocol: tcp
-                        action: accept
-                      - ip_version: ipv6
-                        name: allow-ssh-v6
-                        src_ip: "::/0"
-                        dst_port: "22"
                         protocol: tcp
                         action: accept
         '400':

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -323,9 +323,15 @@ func buildFirewallRules(ruleList []any) []client.FirewallRule {
 
 func flattenFirewallRules(rules []client.FirewallRule) []map[string]any {
 	result := make([]map[string]any, 0, len(rules))
+
 	for _, rule := range rules {
+		ipVersion := rule.IPVersion
+		if ipVersion == "" {
+			ipVersion = "ipv4"
+		}
+
 		result = append(result, map[string]any{
-			"ip_version": rule.IPVersion,
+			"ip_version": ipVersion,
 			"name":       rule.Name,
 			"src_ip":     rule.SrcIP,
 			"src_port":   rule.SrcPort,

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -219,18 +219,20 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	err = hClient.SetFirewall(ctx, client.Firewall{
 		IP:                       server.IP,
 		WhitelistHetznerServices: false,
+		FilterIPv6:               false,
 		Status:                   "active",
 		Rules: client.FirewallRules{
 			Input: []client.FirewallRule{
 				{
-					Name:     "Allow all",
-					SrcIP:    "",
-					SrcPort:  "",
-					DstIP:    "",
-					DstPort:  "",
-					Protocol: "",
-					TCPFlags: "",
-					Action:   "accept",
+					IPVersion: "ipv4",
+					Name:      "Allow all",
+					SrcIP:     "",
+					SrcPort:   "",
+					DstIP:     "",
+					DstPort:   "",
+					Protocol:  "",
+					TCPFlags:  "",
+					Action:    "accept",
 				},
 			},
 		},

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -302,8 +302,6 @@ func buildFirewallRules(ruleList []any) []client.FirewallRule {
 
 	for _, ruleMap := range ruleList {
 		ruleProps := ruleMap.(map[string]any)
-		// ip_version absent from older configs is handled by the schema Default
-		// ("ipv4") and the client-side fallback in SetFirewall.
 		ipVersion, _ := ruleProps["ip_version"].(string)
 		rules = append(rules, client.FirewallRule{
 			IPVersion: ipVersion,

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -45,12 +45,32 @@ func Resource() *schema.Resource {
 				Required:    true,
 				Description: "Whether to whitelist Hetzner services.",
 			},
+			"filter_ipv6": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Whether to also filter IPv6 packets. When false (Hetzner default), " +
+					"only IPv4 rules apply and IPv6 traffic is unrestricted. When true, IPv6 traffic " +
+					"is evaluated against the rule list using the per-rule ip_version field.",
+			},
 			"rule": {
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: maxRulesPerFirewall,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"ip_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ipv4",
+							ValidateDiagFunc: validation.ToDiagFunc(
+								validation.StringInSlice([]string{"ipv4", "ipv6"}, false),
+							),
+							Description: "IP version this rule matches against (ipv4 or ipv6). " +
+								"Defaults to ipv4 to preserve behavior of pre-1.5.0 versions of " +
+								"this provider, which hardcoded ipv4. Note: per the Hetzner Robot " +
+								"API, rules with a `protocol` value require `ip_version` to be set.",
+						},
 						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -124,6 +144,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	err = hClient.SetFirewall(ctx, client.Firewall{
 		IP:                       server.IP,
 		WhitelistHetznerServices: d.Get("whitelist_hos").(bool),
+		FilterIPv6:               d.Get("filter_ipv6").(bool),
 		Status:                   status,
 		Rules:                    client.FirewallRules{Input: rules},
 	})
@@ -162,6 +183,11 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	err = d.Set("whitelist_hos", firewall.WhitelistHetznerServices)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error setting whitelist_hos attribute: %w", err))
+	}
+
+	err = d.Set("filter_ipv6", firewall.FilterIPv6)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error setting filter_ipv6 attribute: %w", err))
 	}
 
 	err = d.Set("rule", flattenFirewallRules(firewall.Rules.Input))
@@ -250,6 +276,11 @@ func resourceFirewallImportState(
 		return nil, fmt.Errorf("error setting whitelist_hos attribute: %w", err)
 	}
 
+	err = d.Set("filter_ipv6", firewall.FilterIPv6)
+	if err != nil {
+		return nil, fmt.Errorf("error setting filter_ipv6 attribute: %w", err)
+	}
+
 	err = d.Set("rule", flattenFirewallRules(firewall.Rules.Input))
 	if err != nil {
 		return nil, fmt.Errorf("error setting rule attribute: %w", err)
@@ -271,15 +302,19 @@ func buildFirewallRules(ruleList []any) []client.FirewallRule {
 
 	for _, ruleMap := range ruleList {
 		ruleProps := ruleMap.(map[string]any)
+		// ip_version absent from older configs is handled by the schema Default
+		// ("ipv4") and the client-side fallback in SetFirewall.
+		ipVersion, _ := ruleProps["ip_version"].(string)
 		rules = append(rules, client.FirewallRule{
-			Name:     ruleProps["name"].(string),
-			SrcIP:    ruleProps["src_ip"].(string),
-			SrcPort:  ruleProps["src_port"].(string),
-			DstIP:    ruleProps["dst_ip"].(string),
-			DstPort:  ruleProps["dst_port"].(string),
-			Protocol: ruleProps["protocol"].(string),
-			TCPFlags: ruleProps["tcp_flags"].(string),
-			Action:   ruleProps["action"].(string),
+			IPVersion: ipVersion,
+			Name:      ruleProps["name"].(string),
+			SrcIP:     ruleProps["src_ip"].(string),
+			SrcPort:   ruleProps["src_port"].(string),
+			DstIP:     ruleProps["dst_ip"].(string),
+			DstPort:   ruleProps["dst_port"].(string),
+			Protocol:  ruleProps["protocol"].(string),
+			TCPFlags:  ruleProps["tcp_flags"].(string),
+			Action:    ruleProps["action"].(string),
 		})
 	}
 
@@ -290,14 +325,15 @@ func flattenFirewallRules(rules []client.FirewallRule) []map[string]any {
 	result := make([]map[string]any, 0, len(rules))
 	for _, rule := range rules {
 		result = append(result, map[string]any{
-			"name":      rule.Name,
-			"src_ip":    rule.SrcIP,
-			"src_port":  rule.SrcPort,
-			"dst_ip":    rule.DstIP,
-			"dst_port":  rule.DstPort,
-			"protocol":  rule.Protocol,
-			"tcp_flags": rule.TCPFlags,
-			"action":    rule.Action,
+			"ip_version": rule.IPVersion,
+			"name":       rule.Name,
+			"src_ip":     rule.SrcIP,
+			"src_port":   rule.SrcPort,
+			"dst_ip":     rule.DstIP,
+			"dst_port":   rule.DstPort,
+			"protocol":   rule.Protocol,
+			"tcp_flags":  rule.TCPFlags,
+			"action":     rule.Action,
 		})
 	}
 


### PR DESCRIPTION
## Problem

The provider currently hardcodes `ip_version=ipv4` on every firewall rule it sends and doesn't expose `filter_ipv6` at all. This makes two real-world scenarios impossible:

1. **IPv6 rules** — every rule the provider sends is forced to ipv4. Users can't say "allow inbound SSH on IPv6".
2. **Per-rule IP version selection** — `ip_version` is in the Hetzner API rule schema but absent from the provider schema; users can't choose v4 vs v6 per rule, so the typical v4+v6 duplicate-rule pattern requires direct API calls.

Symptom that brought me here: trying to apply a tightened firewall via this provider, I got `400 INVALID_INPUT: rules` until I worked out (via the Ansible `community.hrobot` docs) that the API requires `ip_version` whenever `protocol` is set on a rule. The provider injects `ip_version=ipv4` automatically, so simple TCP/UDP rules work — but there's no way to model IPv6 traffic at all.

## Changes

- **Per-rule `ip_version`** (`Optional`, `Default: "ipv4"`, validated against `ipv4`/`ipv6`). The default preserves the exact wire-format behavior of pre-1.5.0 versions of this provider — existing configs continue to work unchanged.
- **Top-level `filter_ipv6`** (`Optional`, `Default: false`, matching Hetzner's API default).
- Client `SetFirewall` now sends both; `GetFirewall` unmarshals both (`filter_ipv6` and per-rule `ip_version` were silently dropped before).
- `Read` + `ImportState` populate the new attributes on state.
- Mock OpenAPI spec example expanded to include `filter_ipv6: true` and a representative v6 rule. Tests round-trip both new fields.
- `examples/resources/hetznerrobot_firewall/resource.tf` + generated `docs/resources/firewall.md` updated.

## Backward compatibility

- Existing configs that don't set `ip_version` per rule get the schema default `"ipv4"`, identical to the previous hardcoded value — no behavior change.
- Existing configs that don't set `filter_ipv6` get `false`, which is the same value the Hetzner API uses when the field is omitted from a POST (the previous client behavior).

## Testing

```
$ go test ./...
ok    github.com/yellowhat/terraform-provider-hetznerrobot/hetznerrobot
ok    github.com/yellowhat/terraform-provider-hetznerrobot/internal/client
ok    github.com/yellowhat/terraform-provider-hetznerrobot/internal/vswitch
```

The mock-server tests now verify the new fields round-trip end-to-end (set in client → POSTed → mock returns in GET → unmarshalled correctly).

## Not in scope

- I didn't add automatic v4-mirroring (i.e. "when ip_version=ipv6 is omitted, also send a v6 variant"). Users who want both still write two rules. Happy to add a wrapper if you prefer.